### PR TITLE
Workaround for O-Preview crash

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -1122,7 +1122,7 @@ public class StickyListHeadersListView extends FrameLayout {
     @Override
     public Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
-        if (superState != BaseSavedState.EMPTY_STATE) {
+        if (superState != BaseSavedState.EMPTY_STATE && false /* Has to be disabled on O-Preview */) {
           throw new IllegalStateException("Handling non empty state of parent class is not implemented");
         }
         return mList.onSaveInstanceState();


### PR DESCRIPTION
Hi Michael,
following up on our email communication, I yesterday spend the evening fixing the MyExpenses app on my Nexus 6P - I still can't really tell why this crash is happening, but I found out that the below "workaround", which just disables the exception, thankfully doesn't have any side-effects - the super state wasn't handled anyway, just the list state gets returned to the parent class, thus saved. I therefore propose just removing the whole `if` statement completely, and not actually merging this dummy PR. ;)